### PR TITLE
MI-207 Added duration of travel metric to the database

### DIFF
--- a/src/mRides-server/Controllers/RideController.cs
+++ b/src/mRides-server/Controllers/RideController.cs
@@ -68,5 +68,17 @@ namespace mRides_server.Controllers
             _rideCatalog.setDistanceTravelled(rideId, distanceMetric);
         }
 
+        /// <summary>
+        /// Method used to set the duration attribute of a ride
+        /// </summary>
+        // POST api/values
+        [HttpPost]
+        public void setDuration([FromBody]dynamic sentObject)
+        {
+            int rideId = sentObject.rideId;
+            long durationMetric = sentObject.duration;
+            _rideCatalog.setDuration(rideId, durationMetric);
+        }
+
     }
 }

--- a/src/mRides-server/Logic/RideCatalog.cs
+++ b/src/mRides-server/Logic/RideCatalog.cs
@@ -113,5 +113,15 @@ namespace mRides_server.Logic
             _context.SaveChanges();
         }
 
+        /// <summary>
+        /// Method used to update the duration attribute of a given ride
+        /// </summary>
+        public void setDuration(int rideId, long durationMetric)
+        {
+            Ride r = getRide(rideId);
+            r.duration = durationMetric;
+            _context.SaveChanges();
+        }
+
     }
 }

--- a/src/mRides-server/Migrations/20170409052331_durationTraveledMetric.Designer.cs
+++ b/src/mRides-server/Migrations/20170409052331_durationTraveledMetric.Designer.cs
@@ -8,9 +8,10 @@ using mRides_server.Data;
 namespace mRidesserver.Migrations
 {
     [DbContext(typeof(ServerContext))]
-    partial class ServerContextModelSnapshot : ModelSnapshot
+    [Migration("20170409052331_durationTraveledMetric")]
+    partial class durationTraveledMetric
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
             modelBuilder
                 .HasAnnotation("ProductVersion", "1.1.0-rtm-22752");

--- a/src/mRides-server/Migrations/20170409052331_durationTraveledMetric.cs
+++ b/src/mRides-server/Migrations/20170409052331_durationTraveledMetric.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace mRidesserver.Migrations
+{
+    public partial class durationTraveledMetric : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "duration",
+                table: "Ride",
+                nullable: true,
+                defaultValue: 0L);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "duration",
+                table: "Ride");
+        }
+    }
+}

--- a/src/mRides-server/Models/Ride.cs
+++ b/src/mRides-server/Models/Ride.cs
@@ -14,6 +14,7 @@ namespace mRides_server.Models
         public DateTime dateTime { get; set; }
         public Boolean isWeekly { get; set; }
         public double distanceTravelled { get; set; }
+        public long duration { get; set; }
 
         [NotMapped]
         public string type;


### PR DESCRIPTION
Added duration of travel metric to the database, Ride table. It's stored as a long attribute of the duration of the ride in seconds. This is because the team just realized that duration should also be stored as it is a metric that the product owner might need to have in the future, which is why it wasn't done in a previous pull request. 
Also added the respective code to update this value in the database in the ride controller and ride catalog, along with their respective documentation (XML comments).